### PR TITLE
feat: add SSH profile scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A plugin that provides quick command functionality for Tabby terminal.
 - Delayed Execution: Support adding delays between commands
 - Enter Control: Option to automatically add carriage return at the end of commands
 - Parameterized Commands: Support for defining and using parameters within commands
+- SSH Profile Scoping: Limit commands or command groups to specific saved SSH profiles
 
 ## Hotkeys
 
@@ -40,6 +41,17 @@ Each command contains the following properties:
 - text: Command content
 - appendCR: Whether to automatically add carriage return (true/false)
 - group: Command group (optional)
+- SSH profiles: Optional list of saved SSH profiles where the command is available
+
+### SSH Profile Scoping
+
+Commands and groups can be bound to one or more saved SSH profiles from Tabby's
+Profiles & connections settings.
+
+- If no SSH profile is selected, the command or group is available in every terminal tab.
+- If one or more SSH profiles are selected, the command or group is shown only when the active tab uses one of those profiles.
+- If both a command and its group have SSH profile limits, both limits must match.
+- Non-matching commands are hidden from the quick command menu and ignored by command shortcuts.
 
 ### Special Syntax
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -4,9 +4,22 @@ export interface QuickCmds {
     appendCR: boolean
     group?: string
     shortcut?: string
+    profileIds?: string[]
 }
 
 export interface ICmdGroup {
     name: string
     cmds: QuickCmds[]
+    profileIds?: string[]
+}
+
+export interface QuickCmdsGroupScope {
+    name: string
+    profileIds?: string[]
+}
+
+export interface SSHProfileOption {
+    id: string
+    name: string
+    description: string
 }

--- a/src/buttonProvider.ts
+++ b/src/buttonProvider.ts
@@ -4,6 +4,7 @@ import { HotkeysService, ToolbarButtonProvider, IToolbarButton, ConfigService, A
 import { QuickCmdsModalComponent } from './components/quickCmdsModal.component'
 import { BaseTerminalTabComponent as TerminalTabComponent } from 'tabby-terminal';
 import { QuickCmds } from './api'
+import { commandVisibleForContext, getRuntimeSSHContext } from './sshScope'
 
 @Injectable()
 export class ButtonProvider extends ToolbarButtonProvider {
@@ -86,7 +87,9 @@ export class ButtonProvider extends ToolbarButtonProvider {
             
             // Check if this shortcut matches any command
             const commands = this.config.store.qc.cmds
-            const matchedCommand = commands.find(cmd => cmd.shortcut === shortcut)
+            const context = getRuntimeSSHContext(this.app.activeTab)
+            const groups = this.getGroupScopes()
+            const matchedCommand = commands.find(cmd => cmd.shortcut === shortcut && commandVisibleForContext(cmd, groups, context))
             
             // If a command is matched, prevent the default behavior to avoid sending extra escape sequences
             if (matchedCommand) {
@@ -99,7 +102,9 @@ export class ButtonProvider extends ToolbarButtonProvider {
 
     async executeCommandByShortcut(hotkey: string) {
         const commands = this.config.store.qc.cmds
-        const matchedCommand = commands.find(cmd => cmd.shortcut === hotkey)
+        const context = getRuntimeSSHContext(this.app.activeTab)
+        const groups = this.getGroupScopes()
+        const matchedCommand = commands.find(cmd => cmd.shortcut === hotkey && commandVisibleForContext(cmd, groups, context))
         
         if (matchedCommand) {
             // Use count +1 and persist
@@ -114,6 +119,9 @@ export class ButtonProvider extends ToolbarButtonProvider {
     async _send (tab: BaseTabComponent, quick_cmd: QuickCmds) {
         if (tab instanceof SplitTabComponent) {
             this._send((tab as SplitTabComponent).getFocusedTab(), quick_cmd)
+            return
+        }
+        if (!commandVisibleForContext(quick_cmd, this.getGroupScopes(), getRuntimeSSHContext(tab))) {
             return
         }
         if (tab instanceof TerminalTabComponent) {
@@ -201,5 +209,13 @@ export class ButtonProvider extends ToolbarButtonProvider {
                 this.activate()
             }
         }]
+    }
+
+    private getGroupScopes () {
+        return (this.config.store.qc.groups ?? []).map(group => ({
+            name: group.name,
+            cmds: [],
+            profileIds: group.profileIds ?? [],
+        }))
     }
 }

--- a/src/components/editCommandModal.component.pug
+++ b/src/components/editCommandModal.component.pug
@@ -55,6 +55,19 @@
         toggle(
             [(ngModel)]='command.appendCR',
         )
+
+    .form-group
+        label SSH profiles
+        .form-text.text-muted.mb-2 Leave empty to show this command in every terminal tab.
+        .list-group.ssh-profile-list
+            label.list-group-item.d-flex.align-items-center(*ngFor='let profile of profiles')
+                input.form-check-input.me-2(
+                    type='checkbox',
+                    [checked]='isProfileSelected(profile.id)',
+                    (change)='toggleProfile(profile.id)',
+                )
+                span.mr-auto {{ profile.name }}
+                small.text-muted {{ profile.description }}
                     
 .modal-footer
     button.btn.btn-outline-primary((click)='save()') Save

--- a/src/components/editCommandModal.component.ts
+++ b/src/components/editCommandModal.component.ts
@@ -1,12 +1,13 @@
 import { Component, HostListener } from '@angular/core'
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap'
-import { QuickCmds } from '../api'
+import { QuickCmds, SSHProfileOption } from '../api'
 
 @Component({
     template: require('./editCommandModal.component.pug'),
 })
 export class EditCommandModalComponent {
     allGroups: string[] = []
+    profiles: SSHProfileOption[] = []
     command: QuickCmds
     isCapturingShortcut: boolean = false
     specialCommandsInfo: string = 'Special commands:<br> \\x<xx> for control characters, \\s<ms> for delays, ${parameterName} for parameters.'
@@ -84,7 +85,18 @@ export class EditCommandModalComponent {
         this.isCapturingShortcut = true
     }
 
+    isProfileSelected (profileId: string): boolean {
+        return (this.command.profileIds ?? []).includes(profileId)
+    }
+
+    toggleProfile (profileId: string) {
+        const ids = new Set(this.command.profileIds ?? [])
+        ids.has(profileId) ? ids.delete(profileId) : ids.add(profileId)
+        this.command.profileIds = Array.from(ids)
+    }
+
     save () {
+        this.command.profileIds = this.command.profileIds ?? []
         this.modalInstance.close(this.command)
     }
 

--- a/src/components/editGroupModal.component.ts
+++ b/src/components/editGroupModal.component.ts
@@ -1,0 +1,62 @@
+import { Component, Input } from '@angular/core'
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap'
+import { ICmdGroup, SSHProfileOption } from '../api'
+
+@Component({
+    template: `
+        <div class="modal-body">
+            <div class="form-group">
+                <label>Name</label>
+                <input class="form-control" type="text" autofocus [(ngModel)]="group.name">
+            </div>
+            <div class="form-group mt-3">
+                <label>SSH profiles</label>
+                <div class="form-text text-muted mb-2">Leave empty to show this group in every terminal tab.</div>
+                <div class="list-group ssh-profile-list">
+                    <label class="list-group-item d-flex align-items-center" *ngFor="let profile of profiles">
+                        <input class="form-check-input me-2" type="checkbox" [checked]="isSelected(profile.id)" (change)="toggleProfile(profile.id)">
+                        <span class="me-auto">{{ profile.name }}</span>
+                        <small class="text-muted">{{ profile.description }}</small>
+                    </label>
+                </div>
+            </div>
+        </div>
+        <div class="modal-footer">
+            <button class="btn btn-outline-primary" (click)="save()">Save</button>
+            <button class="btn btn-outline-danger" (click)="cancel()">Cancel</button>
+        </div>
+    `,
+    styles: [`
+        .ssh-profile-list {
+            max-height: 220px;
+            overflow: auto;
+        }
+    `],
+})
+export class EditGroupModalComponent {
+    @Input() group: ICmdGroup
+    @Input() profiles: SSHProfileOption[] = []
+
+    constructor (
+        private modalInstance: NgbActiveModal,
+    ) {
+    }
+
+    isSelected (profileId: string): boolean {
+        return (this.group.profileIds ?? []).includes(profileId)
+    }
+
+    toggleProfile (profileId: string) {
+        const ids = new Set(this.group.profileIds ?? [])
+        ids.has(profileId) ? ids.delete(profileId) : ids.add(profileId)
+        this.group.profileIds = Array.from(ids)
+    }
+
+    save () {
+        this.modalInstance.close(this.group)
+    }
+
+    cancel () {
+        this.modalInstance.dismiss()
+    }
+}

--- a/src/components/quickCmdsModal.component.ts
+++ b/src/components/quickCmdsModal.component.ts
@@ -1,11 +1,12 @@
 import { Component } from '@angular/core'
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
-import { ConfigService, AppService, BaseTabComponent, SplitTabComponent } from 'tabby-core'
-import { QuickCmds, ICmdGroup } from '../api'
+import { ConfigService, AppService, BaseTabComponent, SplitTabComponent, ProfilesService } from 'tabby-core'
+import { QuickCmds, ICmdGroup, SSHProfileOption } from '../api'
 import { EditCommandModalComponent } from './editCommandModal.component'
 import { BaseTerminalTabComponent as TerminalTabComponent } from 'tabby-terminal';
 import { ParameterPromptModalComponent } from './parameterPromptModal.component'
+import { commandVisibleForContext, getRuntimeSSHContext } from '../sshScope'
 
 
 interface FlattenedItem {
@@ -26,6 +27,7 @@ export class QuickCmdsModalComponent {
     quickCmd: string
     appendCR: boolean
     childGroups: ICmdGroup[]
+    profiles: SSHProfileOption[] = []
     groupCollapsed: {[id: string]: boolean} = {}
     expandedGroups: { [id: string]: boolean } = {}
     private flattenedItems: FlattenedItem[] = []
@@ -40,6 +42,7 @@ export class QuickCmdsModalComponent {
         private ngbModal: NgbModal,
         private config: ConfigService,
         private app: AppService,
+        private profilesService: ProfilesService,
     ) { }
 
     ngOnInit () {
@@ -50,9 +53,23 @@ export class QuickCmdsModalComponent {
         } catch {}
 
         this.cmds = this.config.store.qc.cmds
+        this.config.store.qc.groups = this.config.store.qc.groups ?? []
         this.appendCR = true
         this.refresh()
         this.updateFlattenedItems()
+        this.loadProfiles()
+    }
+
+    async loadProfiles () {
+        const profiles = await this.profilesService.getProfiles()
+        this.profiles = profiles
+            .filter(profile => profile.type === 'ssh' && !!profile.id)
+            .map(profile => ({
+                id: profile.id,
+                name: profile.name,
+                description: this.describeProfile(profile),
+            }))
+            .sort((a, b) => a.name.localeCompare(b.name))
     }
 
     quickSend () {
@@ -113,6 +130,10 @@ export class QuickCmdsModalComponent {
         
         if (tab instanceof SplitTabComponent) {
             this._send((tab as SplitTabComponent).getFocusedTab(), quick_cmd)
+            return
+        }
+        if (!commandVisibleForContext(quick_cmd, this.getGroupScopes(), getRuntimeSSHContext(tab))) {
+            return
         }
         if (tab instanceof TerminalTabComponent) {
             let currentTab = tab as TerminalTabComponent
@@ -226,6 +247,7 @@ export class QuickCmdsModalComponent {
             name: '',
             text: this.quickCmd || '',
             appendCR: true,
+            profileIds: [],
         };
         this.edit(newCommand);
     }
@@ -233,6 +255,7 @@ export class QuickCmdsModalComponent {
     edit (command: QuickCmds) {
         const modal = this.ngbModal.open(EditCommandModalComponent)
         modal.componentInstance.allGroups = Array.from(new Set(this.cmds.map(x => x.group || '')))
+        modal.componentInstance.profiles = this.profiles
         
         const isNew = !this.cmds.includes(command)
         
@@ -283,7 +306,7 @@ export class QuickCmdsModalComponent {
                 return (cmd.name + cmd.group + cmd.text).toLowerCase().includes(this.quickCmd.toLowerCase())
             }
             return true
-        })
+        }).filter(cmd => commandVisibleForContext(cmd, this.getGroupScopes(), getRuntimeSSHContext(this.app.activeTab)))
 
         for (let cmd of cmds) {
             cmd.group = cmd.group || ''
@@ -292,6 +315,7 @@ export class QuickCmdsModalComponent {
                 group = {
                     name: cmd.group,
                     cmds: [],
+                    profileIds: this.getGroupProfileIds(cmd.group),
                 }
                 this.childGroups.push(group)
             }
@@ -331,6 +355,7 @@ export class QuickCmdsModalComponent {
         if (this.quickCmd) {
             // Filter commands that match the search query
             const filteredCmds = this.cmds.filter(cmd => (cmd.name + (cmd.group || '') + cmd.text).toLowerCase().includes(this.quickCmd.toLowerCase()))
+                .filter(cmd => commandVisibleForContext(cmd, this.getGroupScopes(), getRuntimeSSHContext(this.app.activeTab)))
             // Create a temporary set to track groups that contain filtered commands
             const groupsWithFilteredCmds = new Set<string>()
             filteredCmds.forEach(cmd => groupsWithFilteredCmds.add(cmd.group || ''))
@@ -512,5 +537,29 @@ export class QuickCmdsModalComponent {
 
     private getSelectedItem() {
         return this.flattenedItems[this.getSelectedIndex()]
+    }
+
+    private getGroupScopes (): ICmdGroup[] {
+        return (this.config.store.qc.groups ?? []).map(group => ({
+            name: group.name,
+            cmds: [],
+            profileIds: group.profileIds ?? [],
+        }))
+    }
+
+    private getGroupProfileIds (name: string): string[] {
+        return (this.config.store.qc.groups ?? []).find(group => group.name === name)?.profileIds ?? []
+    }
+
+    private describeProfile (profile: any): string {
+        const host = profile.options?.host
+        const user = profile.options?.user
+        const port = profile.options?.port
+
+        if (!host) {
+            return profile.id
+        }
+
+        return `${user ? `${user}@` : ''}${host}${port ? `:${port}` : ''}`
     }
 }

--- a/src/components/quickCmdsSettingsTab.component.pug
+++ b/src/components/quickCmdsSettingsTab.component.pug
@@ -30,6 +30,7 @@ h3 Quick Commands
                     .text-muted
                         span {{cmd.text}}
                         span.ml-1(*ngIf='cmd.appendCR', title='Appends CR') ↵
+                        span.badge.bg-secondary.ml-2(*ngIf='cmd.profileIds?.length') SSH
                 .command-buttons
                     button.btn.btn-outline-info((click)='editCommand(cmd)')
                         i.fa.fa-pencil

--- a/src/components/quickCmdsSettingsTab.component.scss
+++ b/src/components/quickCmdsSettingsTab.component.scss
@@ -11,3 +11,8 @@
     display: flex;
     gap: 5px; /* Add some space between the buttons */
 }
+
+.ssh-profile-list {
+    max-height: 220px;
+    overflow: auto;
+}

--- a/src/components/quickCmdsSettingsTab.component.ts
+++ b/src/components/quickCmdsSettingsTab.component.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core'
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap'
-import { ConfigService } from 'tabby-core'
-import { QuickCmds, ICmdGroup } from '../api'
+import { ConfigService, ProfilesService } from 'tabby-core'
+import { QuickCmds, ICmdGroup, QuickCmdsGroupScope, SSHProfileOption } from '../api'
 import { EditCommandModalComponent } from './editCommandModal.component'
-import { PromptModalComponent } from './promptModal.component'
+import { EditGroupModalComponent } from './editGroupModal.component'
 
 @Component({
     template: require('./quickCmdsSettingsTab.component.pug'),
@@ -14,13 +14,29 @@ export class QuickCmdsSettingsTabComponent {
     commands: QuickCmds[]
     childGroups: ICmdGroup[]
     groupCollapsed: {[id: string]: boolean} = {}
+    profiles: SSHProfileOption[] = []
 
     constructor (
         public config: ConfigService,
         private ngbModal: NgbModal,
+        private profilesService: ProfilesService,
     ) {
         this.commands = this.config.store.qc.cmds
+        this.config.store.qc.groups = this.config.store.qc.groups ?? []
         this.refresh()
+        this.loadProfiles()
+    }
+
+    async loadProfiles () {
+        const profiles = await this.profilesService.getProfiles()
+        this.profiles = profiles
+            .filter(profile => profile.type === 'ssh' && !!profile.id)
+            .map(profile => ({
+                id: profile.id,
+                name: profile.name,
+                description: this.describeProfile(profile),
+            }))
+            .sort((a, b) => a.name.localeCompare(b.name))
     }
 
     createCommand () {
@@ -28,11 +44,13 @@ export class QuickCmdsSettingsTabComponent {
             name: '',
             text: '',
             appendCR: true,
+            profileIds: [],
         }
 
         let modal = this.ngbModal.open(EditCommandModalComponent)
         modal.componentInstance.command = command
         modal.componentInstance.allGroups = Array.from(new Set(this.commands.map(x => x.group || ''))).filter(x => x)
+        modal.componentInstance.profiles = this.profiles
 
         modal.result.then(result => {
             this.commands.push(result)
@@ -47,6 +65,7 @@ export class QuickCmdsSettingsTabComponent {
         // Ensure command.group is an empty string if it's null or undefined
         modal.componentInstance.command = { ...command, group: command.group || 'Ungrouped' }
         modal.componentInstance.allGroups = Array.from(new Set(this.commands.map(x => x.group || ''))).filter(x => x)
+        modal.componentInstance.profiles = this.profiles
         modal.result.then(result => {
             // If the group is 'Ungrouped', set it to null
             if (result.group === 'Ungrouped') {
@@ -68,17 +87,24 @@ export class QuickCmdsSettingsTabComponent {
     }
 
     editGroup (group: ICmdGroup) {
-        let modal = this.ngbModal.open(PromptModalComponent)
-        modal.componentInstance.prompt = 'New group name'
-        modal.componentInstance.value = group.name
+        const modal = this.ngbModal.open(EditGroupModalComponent)
+        modal.componentInstance.group = { name: group.name, cmds: group.cmds, profileIds: group.profileIds ?? [] }
+        modal.componentInstance.profiles = this.profiles
         modal.result.then(result => {
-            if (result) {
-                for (let connection of this.commands.filter(x => x.group === group.name)) {
-                    connection.group = result
-                }
-                this.config.save()
-                this.refresh()
+            if (!result?.name) {
+                return
             }
+
+            const oldName = group.name
+            for (let command of this.commands.filter(x => x.group === oldName)) {
+                command.group = result.name
+            }
+            this.upsertGroupScope(result.name, result.profileIds ?? [])
+            if (oldName !== result.name) {
+                this.removeGroupScope(oldName)
+            }
+            this.config.save()
+            this.refresh()
         })
     }
 
@@ -87,6 +113,7 @@ export class QuickCmdsSettingsTabComponent {
             for (let command of this.commands.filter(x => x.group === group.name)) {
                 command.group = null
             }
+            this.removeGroupScope(group.name)
             this.config.save()
             this.refresh()
         }
@@ -112,11 +139,43 @@ export class QuickCmdsSettingsTabComponent {
                 group = {
                     name: cmd.group,
                     cmds: [],
+                    profileIds: this.getGroupScope(cmd.group).profileIds ?? [],
                 }
                 this.childGroups.push(group)
             }
             group.cmds.push(cmd)
         }
+    }
+
+    private getGroupScope (name: string): QuickCmdsGroupScope {
+        return (this.config.store.qc.groups ?? []).find(x => x.name === name) ?? { name, profileIds: [] }
+    }
+
+    private upsertGroupScope (name: string, profileIds: string[]) {
+        const groups = this.config.store.qc.groups ?? []
+        const existing = groups.find(x => x.name === name)
+        if (existing) {
+            existing.profileIds = profileIds
+        } else {
+            groups.push({ name, profileIds })
+        }
+        this.config.store.qc.groups = groups.filter(x => x.name || (x.profileIds ?? []).length)
+    }
+
+    private removeGroupScope (name: string) {
+        this.config.store.qc.groups = (this.config.store.qc.groups ?? []).filter(x => x.name !== name)
+    }
+
+    private describeProfile (profile: any): string {
+        const host = profile.options?.host
+        const user = profile.options?.user
+        const port = profile.options?.port
+
+        if (!host) {
+            return profile.id
+        }
+
+        return `${user ? `${user}@` : ''}${host}${port ? `:${port}` : ''}`
     }
    
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,8 @@ import { ConfigProvider } from 'tabby-core'
 export class QuickCmdsConfigProvider extends ConfigProvider {
     defaults = {
         qc: {
-            cmds: []
+            cmds: [],
+            groups: [],
         },
         hotkeys: {
             'qc': [

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { QuickCmdsModalComponent } from './components/quickCmdsModal.component'
 import { QuickCmdsSettingsTabComponent } from './components/quickCmdsSettingsTab.component'
 import { PromptModalComponent } from './components/promptModal.component'
 import { ParameterPromptModalComponent } from './components/parameterPromptModal.component'
+import { EditGroupModalComponent } from './components/editGroupModal.component'
 
 import { ButtonProvider } from './buttonProvider'
 import { QuickCmdsConfigProvider } from './config'
@@ -34,6 +35,7 @@ import { QuickCmdsSettingsTabProvider } from './settings'
         QuickCmdsModalComponent,
         QuickCmdsSettingsTabComponent,
         ParameterPromptModalComponent,
+        EditGroupModalComponent,
     ],
     entryComponents: [
         PromptModalComponent,
@@ -41,6 +43,7 @@ import { QuickCmdsSettingsTabProvider } from './settings'
         QuickCmdsModalComponent,
         QuickCmdsSettingsTabComponent,
         ParameterPromptModalComponent,
+        EditGroupModalComponent,
     ],
 })
 export default class QuickCmdsModule { }

--- a/src/sshScope.ts
+++ b/src/sshScope.ts
@@ -1,0 +1,47 @@
+import { BaseTabComponent, SplitTabComponent } from 'tabby-core'
+import { QuickCmds, ICmdGroup, SSHProfileOption } from './api'
+
+export interface RuntimeSSHContext {
+    profileId: string | null
+    isSSH: boolean
+}
+
+export function getFocusedTab (tab: BaseTabComponent | null): BaseTabComponent | null {
+    if (!tab) {
+        return null
+    }
+    if (tab instanceof SplitTabComponent) {
+        return tab.getFocusedTab()
+    }
+    return tab
+}
+
+export function getRuntimeSSHContext (tab: BaseTabComponent | null): RuntimeSSHContext {
+    const focused = getFocusedTab(tab) as any
+    const profile = focused?.profile ?? focused?.sshSession?.profile ?? focused?.session?.profile ?? null
+    const profileId = typeof profile?.id === 'string' ? profile.id : null
+    const isSSH = profile?.type === 'ssh' || (!!profile?.options?.host && !!profile?.options?.user) || String(focused?.constructor?.name ?? '').includes('SSH')
+
+    return { profileId, isSSH }
+}
+
+export function scopedToCurrentProfile (profileIds: string[] | undefined, context: RuntimeSSHContext): boolean {
+    const ids = (profileIds ?? []).filter(Boolean)
+    if (!ids.length) {
+        return true
+    }
+    return context.isSSH && !!context.profileId && ids.includes(context.profileId)
+}
+
+export function commandVisibleForContext (
+    command: QuickCmds,
+    groups: ICmdGroup[],
+    context: RuntimeSSHContext,
+): boolean {
+    const group = groups.find(x => x.name === (command.group || ''))
+    return scopedToCurrentProfile(group?.profileIds, context) && scopedToCurrentProfile(command.profileIds, context)
+}
+
+export function profileLabel (profile: SSHProfileOption): string {
+    return profile.description ? `${profile.name} (${profile.description})` : profile.name
+}


### PR DESCRIPTION
## Summary by Sourcery

为快速命令和命令组添加基于 SSH 配置文件的作用域控制，根据当前激活的 SSH 配置文件决定它们何时显示和执行。

New Features:
- 允许通过命令编辑器 UI，将快速命令限定到特定已保存的 SSH 配置文件。
- 允许通过专用的命令组编辑弹窗，将快速命令组限定到特定已保存的 SSH 配置文件。
- 基于当前标签页的 SSH 连接配置文件，过滤快速命令的可见性、执行以及键盘快捷键。

Enhancements:
- 在配置中持久化命令组级别的 SSH 配置文件作用域，并在运行时逻辑中暴露这些信息。
- 在 UI 中为带有 SSH 作用域的命令和命令组显示可视化标识和配置文件描述，以便更容易定位目标。

Documentation:
- 在 README 中记录快速命令和命令组的 SSH 配置文件作用域行为及其配置选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add SSH profile-based scoping to quick commands and groups, controlling when they appear and execute based on the active SSH profile.

New Features:
- Allow quick commands to be scoped to specific saved SSH profiles via the command editor UI.
- Allow quick command groups to be scoped to specific saved SSH profiles via a dedicated group editing modal.
- Filter quick command visibility, execution, and keyboard shortcuts based on the active tab’s SSH connection profile.

Enhancements:
- Persist group-level SSH profile scopes in configuration and expose them to runtime logic.
- Display SSH-scoped commands and groups with visual indicators and profile descriptions in the UI for easier targeting.

Documentation:
- Document SSH profile scoping behavior and configuration options for quick commands and groups in the README.

</details>