### PR TITLE
Feat/ssh profile scoping

### DIFF
--- a/src/components/editCommandModal.component.pug
+++ b/src/components/editCommandModal.component.pug
@@ -59,8 +59,13 @@
     .form-group
         label SSH profiles
         .form-text.text-muted.mb-2 Leave empty to show this command in every terminal tab.
+        input.form-control.mb-2(
+            type='text',
+            placeholder='Search SSH profiles',
+            [(ngModel)]='sshProfileQuery',
+        )
         .list-group.ssh-profile-list
-            label.list-group-item.d-flex.align-items-center(*ngFor='let profile of profiles')
+            label.list-group-item.d-flex.align-items-center(*ngFor='let profile of filteredProfiles')
                 input.form-check-input.me-2(
                     type='checkbox',
                     [checked]='isProfileSelected(profile.id)',
@@ -68,6 +73,7 @@
                 )
                 span.mr-auto {{ profile.name }}
                 small.text-muted {{ profile.description }}
+            .list-group-item.text-muted(*ngIf='!filteredProfiles.length') No matching SSH profiles
                     
 .modal-footer
     button.btn.btn-outline-primary((click)='save()') Save

--- a/src/components/editCommandModal.component.ts
+++ b/src/components/editCommandModal.component.ts
@@ -1,15 +1,23 @@
 import { Component, HostListener } from '@angular/core'
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap'
 import { QuickCmds, SSHProfileOption } from '../api'
+import { profileMatchesQuery } from '../sshScope'
 
 @Component({
     template: require('./editCommandModal.component.pug'),
+    styles: [`
+        .ssh-profile-list {
+            max-height: 220px;
+            overflow: auto;
+        }
+    `],
 })
 export class EditCommandModalComponent {
     allGroups: string[] = []
     profiles: SSHProfileOption[] = []
     command: QuickCmds
     isCapturingShortcut: boolean = false
+    sshProfileQuery: string = ''
     specialCommandsInfo: string = 'Special commands:<br> \\x<xx> for control characters, \\s<ms> for delays, ${parameterName} for parameters.'
 
     constructor (
@@ -83,6 +91,10 @@ export class EditCommandModalComponent {
     startCaptureShortcut(event: Event) {
         event.preventDefault()
         this.isCapturingShortcut = true
+    }
+
+    get filteredProfiles (): SSHProfileOption[] {
+        return this.profiles.filter(profile => profileMatchesQuery(profile, this.sshProfileQuery))
     }
 
     isProfileSelected (profileId: string): boolean {

--- a/src/components/editGroupModal.component.ts
+++ b/src/components/editGroupModal.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core'
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap'
 import { ICmdGroup, SSHProfileOption } from '../api'
+import { profileMatchesQuery } from '../sshScope'
 
 @Component({
     template: `
@@ -12,12 +13,14 @@ import { ICmdGroup, SSHProfileOption } from '../api'
             <div class="form-group mt-3">
                 <label>SSH profiles</label>
                 <div class="form-text text-muted mb-2">Leave empty to show this group in every terminal tab.</div>
+                <input class="form-control mb-2" type="text" placeholder="Search SSH profiles" [(ngModel)]="sshProfileQuery">
                 <div class="list-group ssh-profile-list">
-                    <label class="list-group-item d-flex align-items-center" *ngFor="let profile of profiles">
+                    <label class="list-group-item d-flex align-items-center" *ngFor="let profile of filteredProfiles">
                         <input class="form-check-input me-2" type="checkbox" [checked]="isSelected(profile.id)" (change)="toggleProfile(profile.id)">
                         <span class="me-auto">{{ profile.name }}</span>
                         <small class="text-muted">{{ profile.description }}</small>
                     </label>
+                    <div class="list-group-item text-muted" *ngIf="!filteredProfiles.length">No matching SSH profiles</div>
                 </div>
             </div>
         </div>
@@ -36,10 +39,15 @@ import { ICmdGroup, SSHProfileOption } from '../api'
 export class EditGroupModalComponent {
     @Input() group: ICmdGroup
     @Input() profiles: SSHProfileOption[] = []
+    sshProfileQuery: string = ''
 
     constructor (
         private modalInstance: NgbActiveModal,
     ) {
+    }
+
+    get filteredProfiles (): SSHProfileOption[] {
+        return this.profiles.filter(profile => profileMatchesQuery(profile, this.sshProfileQuery))
     }
 
     isSelected (profileId: string): boolean {

--- a/src/sshScope.ts
+++ b/src/sshScope.ts
@@ -45,3 +45,16 @@ export function commandVisibleForContext (
 export function profileLabel (profile: SSHProfileOption): string {
     return profile.description ? `${profile.name} (${profile.description})` : profile.name
 }
+
+export function profileMatchesQuery (profile: SSHProfileOption, query: string): boolean {
+    const normalizedQuery = query.trim().toLowerCase()
+    if (!normalizedQuery) {
+        return true
+    }
+
+    return [
+        profile.id,
+        profile.name,
+        profile.description,
+    ].some(value => (value ?? '').toLowerCase().includes(normalizedQuery))
+}


### PR DESCRIPTION
Add search field under ssh list

## Summary by Sourcery

在命令和分组编辑弹窗中为 SSH 配置添加基于搜索的筛选功能。

新功能：
- 引入一个可复用的辅助工具，用于根据文本查询按 id、名称或描述匹配 SSH 配置。
- 在命令和分组编辑弹窗中的 SSH 配置列表中添加搜索字段，实现实时筛选和空状态提示。

增强：
- 在编辑命令弹窗中限制 SSH 配置列表的高度并启用滚动，以提升可用性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add search-based filtering for SSH profiles in command and group edit modals.

New Features:
- Introduce a reusable helper to match SSH profiles against a text query by id, name, or description.
- Add search fields to SSH profile lists in command and group edit modals with live filtering and empty-state messaging.

Enhancements:
- Constrain SSH profile list height with scrolling in the edit command modal for better usability.

</details>